### PR TITLE
Allow administrator to see activity for all roles, even custom roles

### DIFF
--- a/classes/class-aal-activity-log-list-table.php
+++ b/classes/class-aal-activity-log-list-table.php
@@ -88,10 +88,17 @@ class AAL_Activity_Log_List_Table extends WP_List_Table {
 			)
 		);
 
+		global $wp_roles;
+
+		$all_roles = array();
+		foreach ( $wp_roles->roles as $key=>$wp_role ) {
+			$all_roles[] = $key;
+		}
+
 		$this->_caps = apply_filters(
 			'aal_init_caps',
 			array(
-				'administrator' => array( 'administrator', 'editor', 'author', 'guest' ),
+				'administrator' => $all_roles,
 				'editor'        => array( 'editor', 'author', 'guest' ),
 				'author'        => array( 'author', 'guest' ),
 			)


### PR DESCRIPTION
https://wordpress.org/support/topic/activity-for-custom-user-roles-is-not-appearing-in-logs
