### PR TITLE
Get real IP if using Cloudflare

### DIFF
--- a/classes/class-aal-api.php
+++ b/classes/class-aal-api.php
@@ -40,6 +40,7 @@ class AAL_API {
 			'HTTP_FORWARDED_FOR',
 			'HTTP_FORWARDED',
 			'REMOTE_ADDR',
+			'HTTP_CF_CONNECTING_IP',
 		);
 		
 		foreach ( $server_ip_keys as $key ) {


### PR DESCRIPTION
Logs the real IP for sites using Cloudflare, using the "CF-Connecting-IP" HTTP header to get a visitor IP.