### PR TITLE
Fix plugin auto updates don't create a log

### DIFF
--- a/hooks/class-aal-hook-plugins.php
+++ b/hooks/class-aal-hook-plugins.php
@@ -87,10 +87,11 @@ class AAL_Hook_Plugins extends AAL_Hook_Base {
 			if ( isset( $extra['bulk'] ) && true == $extra['bulk'] ) {
 				$slugs = $extra['plugins'];
 			} else {
-				if ( ! isset( $upgrader->skin->plugin ) )
+				$slug = ( isset( $upgrader->skin->plugin ) ? $upgrader->skin->plugin : $extra['plugin'] );
+				if ( empty( $slug ))
 					return;
 				
-				$slugs = array( $upgrader->skin->plugin );
+				$slugs = array( $slug );
 			}
 			
 			foreach ( $slugs as $slug ) {


### PR DESCRIPTION
Hello
I identified a case where automatic upgrades for plugins don't trigger an activity log.

It's when `$extra['bulk']`=false, and also `$upgrader->skin->plugin` is not defined, so it returns without creating a log.

My PR tries to find the plugin slug in the `$extra` var.

Can you consider this?
Thank you